### PR TITLE
chore: update version to 1.2.0 in package.json and package-lock.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Artifacts are created in `release/` using these patterns:
 
 ## Release Workflow
 
-- GitHub workflow runs on `v*` tags (for example `v1.0.10`).
+- GitHub workflow runs on `v*` tags (for example `v1.2.0`).
 - Release notes are auto-generated from commits between the previous release tag and the current tag.
 - Notes are grouped into `Features`, `Fixes`, and `Other Changes` based on commit message prefix.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "streamfetch",
-  "version": "1.0.10",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "streamfetch",
-      "version": "1.0.10",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "react": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "streamfetch",
-  "version": "1.0.10",
+  "version": "1.2.0",
   "description": "Windows desktop video downloader powered by Electron, React, and yt-dlp.",
   "main": "electron/main.js",
   "author": "StreamFetch Team",


### PR DESCRIPTION
This pull request updates the project version from 1.0.10 to 1.2.0. The most important changes are:

Version bump:

* Updated the version number in `package.json` from `1.0.10` to `1.2.0`, preparing the project for a new release.

Documentation update:

* Updated the release workflow example in `README.md` to reference the new version tag format (`v1.2.0` instead of `v1.0.10`).